### PR TITLE
newer versions of docker compose does not require dash in command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ Make sure to provide actual DB connection parameters:
 ```docker run -p 8080:8080 -e DB_URL=jdbc:postgresql://localhost:5432/postgres -e DB_USERNAME=postgres -e  DB_PASSWORD=db-password -t customer-service:0.0.1```
 
 ### Service assembly via docker-compose.yml:
-```docker-compose build```
+```docker compose build```
 
 ### Running the service together with postgresql db container via docker-compose.yml:
-```docker-compose up```
+```docker compose up```
 
 ### Print the list of containers
-```docker-compose ps```
+```docker compose ps```
 
 ### Display a list of images
-```docker-compose images```
+```docker compose images```
 


### PR DESCRIPTION
newer versions of docker compose does not require dash in command line